### PR TITLE
Use jenkins-plugin-cli command to install plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN usermod -aG docker jenkins
 
 USER jenkins
 COPY plugins.txt /usr/share/jenkins/plugins.txt
-RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt
+RUN jenkins-plugin-cli -f /usr/share/jenkins/plugins.txt
 
 COPY settings.xml /root/.m2/
 


### PR DESCRIPTION
Dockerfile has to be updated with new command to install jenkins plugins.
Current version of jenkin image doesn't have plugins.sh anymore.  Use jenkins-plugin-cli to install plugins instead.